### PR TITLE
Exchange colors for type-face and builtin-face

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Or you can add this to your `init.el`
 ```
 
 ## Screenshots
-![Ruby code](https://cloud.githubusercontent.com/assets/1572403/19900204/b4de482c-a088-11e6-90d3-7a69a6d33ff0.png)
-![Helm](https://cloud.githubusercontent.com/assets/1572403/19900402/609f6d58-a089-11e6-912a-86f992e139fe.png)
+![Ruby code](https://cloud.githubusercontent.com/assets/1572403/19941425/0bb6ff72-a156-11e6-969f-ae0ee02884b5.png)
+![Helm](https://cloud.githubusercontent.com/assets/1572403/19941509/5f115bf4-a156-11e6-8906-06eb190b25cf.png)
 
 ## Contributing
 This is a work in progress and a lot of modes are unsupported. If you want a

--- a/railscasts-reloaded-theme.el
+++ b/railscasts-reloaded-theme.el
@@ -61,8 +61,8 @@
   `(minibuffer-prompt ((t (:foreground ,railscasts-yellow-1))))
 
   ;;;; font-lock-faces
-  `(font-lock-type-face ((t (:foreground ,railscasts-cyan))))
-  `(font-lock-builtin-face ((t (:foreground ,railscasts-red))))
+  `(font-lock-type-face ((t (:foreground ,railscasts-red))))
+  `(font-lock-builtin-face ((t (:foreground ,railscasts-cyan))))
   `(font-lock-constant-face ((t (:foreground ,railscasts-blue))))
   `(font-lock-string-face ((t (:foreground ,railscasts-green))))
   `(font-lock-keyword-face ((t (:foreground ,railscasts-orange))))


### PR DESCRIPTION
This is so that the color for the type-face is a
prominent color that is also suited to the rest of the color
scheme