### PR TITLE
Make comment delimiter color same color as comment face color

### DIFF
--- a/railscasts-reloaded-theme.el
+++ b/railscasts-reloaded-theme.el
@@ -84,6 +84,7 @@
   `(font-lock-variable-name-face ((t (:foreground ,railscasts-lilac))))
   `(font-lock-function-name-face ((t (:foreground ,railscasts-yellow))))
   `(font-lock-comment-face ((t (:foreground ,railscasts-brown))))
+  `(font-lock-comment-delimiter-face ((t (:foreground ,railscasts-brown))))
   `(font-lock-warning-face ((t (:foreground ,railscasts-yellow-1))))
 
   ;;;; package.el


### PR DESCRIPTION
**`font-lock-comment-delimiter-face`**
for comments delimiters, like ‘/*’ and ‘*/’ in C. On most terminals, this inherits from` font-lock-comment-face`. ([Faces for Font Lock](https://www.gnu.org/software/emacs/manual/html_node/elisp/Faces-for-Font-Lock.html))

To avoid this problem:
<img width="268" alt="screen shot 2018-04-07 at 15 27 42" src="https://user-images.githubusercontent.com/18376/38455432-4878ddb0-3a78-11e8-84fa-199d63fa07c2.png">

Thanks